### PR TITLE
Add support for thread dumps with SAP JVM

### DIFF
--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -191,7 +191,10 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 			remoteCommandTokens = append(remoteCommandTokens, "rm -f "+heapdumpFileName)
 		}
 	case threadDumpCommand:
-		remoteCommandTokens = append(remoteCommandTokens, "$(find -executable -name jstack | head -1) $(pidof java)")
+		// OpenJDK
+		remoteCommandTokens = append(remoteCommandTokens, "JSTACK_COMMAND=`find -executable -name jstack | head -1`; if [ -n "${JSTACK_COMMAND}" ]; then ${JSTACK_COMMAND} $(pidof java); fi")
+		// SAP JVM
+		remoteCommandTokens = append(remoteCommandTokens, "JVMMON_COMMAND=`find -executable -name jvmmon | head -1`; if [ -z "${JSTACK_COMMAND}" ] && [ -n "${JVMMON_COMMAND}" ]; then ${JVMMON_COMMAND} -pid $(pidof java) -c \"print stacktrace\"; fi")
 	}
 
 	cfSSHArguments = append(cfSSHArguments, "--command")

--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -192,9 +192,9 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 		}
 	case threadDumpCommand:
 		// OpenJDK
-		remoteCommandTokens = append(remoteCommandTokens, "JSTACK_COMMAND=`find -executable -name jstack | head -1`; if [ -n "${JSTACK_COMMAND}" ]; then ${JSTACK_COMMAND} $(pidof java); fi")
+		remoteCommandTokens = append(remoteCommandTokens, "JSTACK_COMMAND=`find -executable -name jstack | head -1`; if [ -n \"${JSTACK_COMMAND}\" ]; then ${JSTACK_COMMAND} $(pidof java); fi")
 		// SAP JVM
-		remoteCommandTokens = append(remoteCommandTokens, "JVMMON_COMMAND=`find -executable -name jvmmon | head -1`; if [ -z "${JSTACK_COMMAND}" ] && [ -n "${JVMMON_COMMAND}" ]; then ${JVMMON_COMMAND} -pid $(pidof java) -c \"print stacktrace\"; fi")
+		remoteCommandTokens = append(remoteCommandTokens, "JVMMON_COMMAND=`find -executable -name jvmmon | head -1`; if [ -z \"${JSTACK_COMMAND}\" ] && [ -n \"${JVMMON_COMMAND}\" ]; then ${JVMMON_COMMAND} -pid $(pidof java) -c \"print stacktrace\"; fi")
 	}
 
 	cfSSHArguments = append(cfSSHArguments, "--command")


### PR DESCRIPTION
SAP JVM JRE does not include jstack tool. However, it is possible to get the same functionality using the jvmmon binary, which is contained in the SAP JVM JRE. This change utilizes jvmmon to enable thread dump support also for applications running on SAP JVM.