### PR TITLE
Add support for heap dumps with SAP JVM

### DIFF
--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -197,7 +197,7 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 			"OUTPUT=$( ${JVMMON_COMMAND} -pid $(pidof java) -c \"dump heap\" ) || STATUS_CODE=$?",
 			"sleep 5", // Writing the heap dump is triggered asynchronously -> give the jvm some time to create the file
 			"HEAP_DUMP_NAME=`find -name 'java_pid*.hprof' -printf '%T@ %p\\0' | sort -zk 1nr | sed -z 's/^[^ ]* //' | tr '\\0' '\\n' | head -n 1`",
-			"SIZE=-1; OLD_SIZE=$(stat -c '%s' \"${HEAP_DUMP_NAME}\"); while [ \"${SIZE}\" != \"${OLD_SIZE}\" ]; do sleep 1; done",
+			"SIZE=-1; OLD_SIZE=$(stat -c '%s' \"${HEAP_DUMP_NAME}\"); while [ \"${SIZE}\" != \"${OLD_SIZE}\" ]; do sleep 3; SIZE=$(stat -c '%s' \"${HEAP_DUMP_NAME}\"); done",
 			"if [ ! -s \"${HEAP_DUMP_NAME}\" ]; then echo >&2 ${OUTPUT}; exit 1; fi",
 			"if [ ${STATUS_CODE:-0} -gt 0 ]; then echo >&2 ${OUTPUT}; exit ${STATUS_CODE}; fi",
 			"cat ${HEAP_DUMP_NAME}",

--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -206,7 +206,7 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 			// OpenJDK
 			remoteCommandTokens = append(remoteCommandTokens, "rm -f "+heapdumpFileName)
 			// SAP JVM
-			remoteCommandTokens = append(remoteCommandTokens, "if [ -n \"${HEAP_DUMP_NAME}\" ]; then rm -f ${HEAP_DUMP_NAME}; fi")
+			remoteCommandTokens = append(remoteCommandTokens, "if [ -n \"${HEAP_DUMP_NAME}\" ]; then rm -f ${HEAP_DUMP_NAME} ${HEAP_DUMP_NAME%.*}.addons; fi")
 		}
 	case threadDumpCommand:
 		remoteCommandTokens = append(remoteCommandTokens, "$(find -executable -name jstack | head -1) $(pidof java)")


### PR DESCRIPTION
SAP JVM JRE does not include jmap tool. However, it is possible to get the same functionality using the jvmmon binary, which is contained in the SAP JVM JRE. This change utilizes jvmmon to enable heap dump support also for applications running on SAP JVM.