### PR TITLE
fix heap dumps on instances except 0

### DIFF
--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -304,7 +304,7 @@ func (c *JavaPlugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 3,
 			Minor: 0,
-			Build: 2,
+			Build: 3,
 		},
 		MinCliVersion: plugin.VersionType{
 			Major: 6,

--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -244,12 +244,13 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 		return "cf " + strings.Join(cfSSHArguments, " "), nil
 	}
 
-	cfSSHArguments = append(cfSSHArguments, remoteCommand)
+	fullCommand := append(cfSSHArguments, remoteCommand)
 
-	output, err := commandExecutor.Execute(cfSSHArguments)
+	output, err := commandExecutor.Execute(fullCommand)
+
 	if command == heapDumpCommand {
 
-		finalFile, err := util.FindDumpFile(applicationName, heapdumpFileName, fspath)
+		finalFile, err := util.FindDumpFile(cfSSHArguments, heapdumpFileName, fspath)
 		if err == nil && finalFile != "" {
 			heapdumpFileName = finalFile
 			fmt.Println("Successfully created heap dump in application container at: " + heapdumpFileName)
@@ -263,7 +264,7 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 
 		if copyToLocal {
 			localFileFullPath := localDir + "/" + applicationName + "-heapdump-" + uuidGenerator.Generate() + ".hprof"
-			err = util.CopyOverCat(applicationName, heapdumpFileName, localFileFullPath)
+			err = util.CopyOverCat(cfSSHArguments, heapdumpFileName, localFileFullPath)
 			if err == nil {
 				fmt.Println("Heap dump file saved to: " + localFileFullPath)
 			} else {
@@ -274,7 +275,7 @@ func (c *JavaPlugin) execute(commandExecutor cmd.CommandExecutor, uuidGenerator 
 		}
 
 		if !keepAfterDownload {
-			err = util.DeleteRemoteFile(applicationName, heapdumpFileName)
+			err = util.DeleteRemoteFile(cfSSHArguments, heapdumpFileName)
 			if err != nil {
 				return "", err
 			}

--- a/utils/cf_java_plugin_util.go
+++ b/utils/cf_java_plugin_util.go
@@ -3,7 +3,7 @@ package utils
 type CfJavaPluginUtil interface {
 	CheckRequiredTools(app string) (bool, error)
 	GetAvailablePath(data string, userpath string) (string, error)
-	CopyOverCat(app string, src string, dest string) error
-	DeleteRemoteFile(app string, path string) error
-	FindDumpFile(app string, fullpath string, fspath string) (string, error)
+	CopyOverCat(args []string, src string, dest string) error
+	DeleteRemoteFile(args []string, path string) error
+	FindDumpFile(args []string, fullpath string, fspath string) (string, error)
 }

--- a/utils/fakes/fake_utils_impl.go
+++ b/utils/fakes/fake_utils_impl.go
@@ -50,7 +50,7 @@ func (fake FakeCfJavaPluginUtil) GetAvailablePath(data string, userpath string) 
 	return "/tmp", nil
 }
 
-func (fake FakeCfJavaPluginUtil) CopyOverCat(app string, src string, dest string) error {
+func (fake FakeCfJavaPluginUtil) CopyOverCat(args []string, src string, dest string) error {
 
 	if !fake.LocalPathValid {
 		return errors.New("Error occured during create desination file: " + dest + ", please check you are allowed to create file in the path.")
@@ -59,7 +59,7 @@ func (fake FakeCfJavaPluginUtil) CopyOverCat(app string, src string, dest string
 	return nil
 }
 
-func (fake FakeCfJavaPluginUtil) DeleteRemoteFile(app string, path string) error {
+func (fake FakeCfJavaPluginUtil) DeleteRemoteFile(args []string, path string) error {
 	if path != fake.Fspath+"/"+fake.OutputFileName {
 		return errors.New("error occured while removing dump file generated")
 
@@ -68,9 +68,9 @@ func (fake FakeCfJavaPluginUtil) DeleteRemoteFile(app string, path string) error
 	return nil
 }
 
-func (fake FakeCfJavaPluginUtil) FindDumpFile(app string, fullpath string, fspath string) (string, error) {
+func (fake FakeCfJavaPluginUtil) FindDumpFile(args []string, fullpath string, fspath string) (string, error) {
 
-	expectedFullPath := fake.Fspath + "/" + app + "-heapdump-" + fake.UUID + ".hprof"
+	expectedFullPath := fake.Fspath + "/" + args[1] + "-heapdump-" + fake.UUID + ".hprof"
 	if fspath != fake.Fspath || fullpath != expectedFullPath {
 		return "", errors.New("error while checking the generated file")
 	}


### PR DESCRIPTION
Bug: Heap dump is initially correctly created on the specified instance. However, the helper functions only work on the default instance 0, therefore unable to locate the heap dump.
Changes:
- switch argument for helper functions from `app` to `[args]` -> usage is more flexible and all needed parameters, including the app name already correctly appended by the caller, are now passed to the helpers