### PR TITLE
Fix jfr-status, fixes #42

### DIFF
--- a/cf_cli_java_plugin.go
+++ b/cf_cli_java_plugin.go
@@ -278,7 +278,7 @@ fi`,
 		Description:   "Check the running Java Flight Recorder recording on a running Java application",
 		RequiredTools: []string{"jcmd"},
 		GenerateFiles: false,
-		SshCommand:    FilterJCMDRemoteMessage + `$JCMD_COMMAND $(pidof java) JFR.check | filter_jcmd_remote_message`,
+		SshCommand:    FilterJCMDRemoteMessage + `$JCMD_COMMAND $(pidof java) JFR.check | filter_jcmd_remote_message`,
 	},
 	{
 		Name:          "vm-version",


### PR DESCRIPTION
It was caused by a non-space non-character that I must have mistakenly put into the command for jfr-status.